### PR TITLE
HCD-641: Fix flush_and_sync_group returning early with in-flight tasks

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -966,11 +966,11 @@ impl Bus {
         // block on full channels that need flushing. The timeout lets us
         // periodically flush to relieve backpressure while still waiting
         // efficiently for long-running workloads.
-        let mut drain_iters = 0u32;
+        let mut drain_iters = 0u64;
         // Short enough to periodically flush full bounded channels and relieve backpressure,
         // long enough to avoid busy-looping on large workloads (~thousands of concurrent tasks).
         const DRAIN_IDLE_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(100);
-        const DRAIN_WARN_INTERVAL: u32 = 100; // warn every ~10s (100 * DRAIN_IDLE_TIMEOUT)
+        const DRAIN_WARN_INTERVAL: u64 = 100; // warn every ~10s (100 * DRAIN_IDLE_TIMEOUT)
 
         loop {
             drain_iters += 1;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -967,9 +967,21 @@ impl Bus {
         // periodically flush to relieve backpressure while still waiting
         // efficiently for long-running workloads.
         let mut drain_iters = 0u32;
+        // Short enough to periodically flush full bounded channels and relieve backpressure,
+        // long enough to avoid busy-looping on large workloads (~thousands of concurrent tasks).
+        const DRAIN_IDLE_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(100);
+        const DRAIN_WARN_INTERVAL: u32 = 100; // warn every ~10s (100 * DRAIN_IDLE_TIMEOUT)
 
         loop {
             drain_iters += 1;
+            if drain_iters > 1 && drain_iters % DRAIN_WARN_INTERVAL == 0 {
+                log::warn!(
+                    "flush_and_sync_group: group {} drain loop still running after {} iterations, processing_count={}",
+                    group_id,
+                    drain_iters,
+                    self.inner.group_registry.processing_count(group_id)
+                );
+            }
 
             // Flush all receivers in the group to process any partial batches
             // and relieve backpressure on full channels.
@@ -1007,7 +1019,7 @@ impl Bus {
                 self.inner.group_registry.processing_count(group_id)
             );
             let _ = tokio::time::timeout(
-                std::time::Duration::from_millis(100),
+                DRAIN_IDLE_TIMEOUT,
                 self.inner.group_registry.wait_idle(group_id),
             )
             .await;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -959,22 +959,20 @@ impl Bus {
         // handlers completing after the flush can send new messages to batched
         // receivers, creating new partial batches that keep the group counter
         // elevated. We loop until the group truly converges.
-        let drain_fuse_count = 64i32;
-        let mut drain_iters = 0;
+        //
+        // We use wait_idle() with a timeout instead of yield_now(). Plain
+        // yield_now() barely advances the runtime and requires an arbitrary
+        // fuse limit, while unbounded wait_idle() can deadlock when handlers
+        // block on full channels that need flushing. The timeout lets us
+        // periodically flush to relieve backpressure while still waiting
+        // efficiently for long-running workloads.
+        let mut drain_iters = 0u32;
 
         loop {
             drain_iters += 1;
-            if drain_iters > drain_fuse_count {
-                log::warn!(
-                    "flush_and_sync_group: group {} drain loop did not converge after {} iterations, processing_count={}",
-                    group_id,
-                    drain_fuse_count,
-                    self.inner.group_registry.processing_count(group_id)
-                );
-                break;
-            }
 
             // Flush all receivers in the group to process any partial batches
+            // and relieve backpressure on full channels.
             log::debug!(
                 "flush_and_sync_group: group={} drain iteration {} flush, processing_count={}",
                 group_id,
@@ -998,9 +996,21 @@ impl Bus {
                 break;
             }
 
-            // Not yet idle — handlers are still in flight. Yield to let them
-            // make progress, then flush again to catch any new partial batches.
-            tokio::task::yield_now().await;
+            // Not yet idle — handlers are still in flight. Wait for the group
+            // to become idle, but with a timeout so we periodically flush
+            // receivers. Without this, handlers blocked on full channels would
+            // deadlock (they can't complete, so wait_idle never returns, and
+            // nobody flushes to free channel space).
+            log::debug!(
+                "flush_and_sync_group: group={} waiting for idle, processing_count={}",
+                group_id,
+                self.inner.group_registry.processing_count(group_id)
+            );
+            let _ = tokio::time::timeout(
+                std::time::Duration::from_millis(100),
+                self.inner.group_registry.wait_idle(group_id),
+            )
+            .await;
         }
 
         // Sync only receivers that handled messages from this group

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -974,7 +974,7 @@ impl Bus {
 
         loop {
             drain_iters += 1;
-            if drain_iters > 1 && drain_iters % DRAIN_WARN_INTERVAL == 0 {
+            if drain_iters % DRAIN_WARN_INTERVAL == 0 {
                 log::warn!(
                     "flush_and_sync_group: group {} drain loop still running after {} iterations, processing_count={}",
                     group_id,


### PR DESCRIPTION
[HCD-641](https://linear.app/hichee/issue/HCD-641/investigate-job-stage-overlap)
## Summary

  - Fix `flush_and_sync_group` returning early while thousands of tasks are still in flight, which caused job stages to overlap in VRBP (e.g. `scrape_listings` starting while `scrape_urls` was still running)
  - Replace `yield_now()` + 64-iteration fuse in the drain loop with `wait_idle()` + 100ms timeout

  ## Root cause

  The drain loop used `tokio::task::yield_now()` between iterations with a hard fuse limit of 64. For large recursive workloads like URL scraping (~6k concurrent `ScrapeRegionUrls` tasks), 64 single-tick yields was nowhere near enough time for all tasks to complete. When the fuse fired, the function returned early and the caller proceeded to the next stage.

  ## Why not unbounded `wait_idle()`?

  Handlers blocked on full bounded channels need periodic flushing to relieve backpressure. Without the timeout, `wait_idle()` would deadlock: blocked handlers can't complete, so the counter never reaches zero, and nobody flushes to free channel space.

  ## Test plan

  - [x] All 134 existing messagebus tests pass
  - [ ] Run a full scrape job and verify no stage overlap in logs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated group synchronization in the message bus: waiting now uses timeouts and emits periodic warnings for prolonged waits instead of bounded iteration. This reduces busy-waiting, improves efficiency during drain phases, and provides clearer observability of long-running waits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->